### PR TITLE
Allow subclasses to work without an explicit opt-in

### DIFF
--- a/lib/sidekiq/symbols.rb
+++ b/lib/sidekiq/symbols.rb
@@ -2,31 +2,48 @@ require "sidekiq"
 
 module Sidekiq
 module Symbols
+  def self.symbolize_args(args)
+    symbolize_keys = lambda do |arg|
+      h = {}
+      arg.each do |k, v|
+        k = k.to_sym if k.respond_to?(:to_sym)
+        h[k] = v.is_a?(Hash) ? symbolize_keys.call(v) : v
+      end
+      h
+    end
+
+    symbolized_args = args.map do |arg|
+      if arg.is_a?(Hash)
+        symbolize_keys.call(arg)
+      else
+        arg
+      end
+    end.to_a
+  end
+
   def self.included(klass)
     klass.class_eval { prepend(Symbolizer) }
+
+    # Avoid trampling on an existing `inherited` definition.
+    class <<klass
+      prepend(Module.new {
+        def inherited(subclass)
+          subclass.class_eval { prepend(SubclassSymbolizer) }
+          super
+        end
+      })
+    end
   end
 
   module Symbolizer
     def perform(*args)
-      symbolized_args = args.map do |arg|
-        if arg.is_a?(Hash)
-          __sidekiq_symbols_symbolize_keys(arg)
-        else
-          arg
-        end
-      end.to_a
-      super(*symbolized_args)
+      super(*Sidekiq::Symbols.symbolize_args(args))
     end
+  end
 
-    private
-
-    def __sidekiq_symbols_symbolize_keys(arg)
-      h = {}
-      arg.each do |k, v|
-        k = k.to_sym if k.respond_to?(:to_sym)
-        h[k] = v.is_a?(Hash) ? __sidekiq_symbols_symbolize_keys(v) : v
-      end
-      h
+  module SubclassSymbolizer
+    def perform(*args)
+      super(*Sidekiq::Symbols.symbolize_args(args))
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,8 +14,24 @@ RSpec.configure do |config|
   if config.files_to_run.one?
     config.full_backtrace = true
   end
+end
 
+# sidekiq test configuration
+RSpec.configure do |config|
+  config.before(:each) do |example_method|
+    # Clears out the jobs for tests using the fake testing
+    Sidekiq::Worker.clear_all
+  end
+
+  # use an around to allow each test to specify
+  # its own around block and override the testing
+  # context.
   config.around(:each) do |example|
-    Sidekiq::Testing.inline!(&example)
+    # acceptance tests run the jobs immediately.
+    if example.metadata[:type] == :feature || example.metadata[:sidekiq] == :inline
+      Sidekiq::Testing.inline!(&example)
+    else
+      Sidekiq::Testing.fake!(&example)
+    end
   end
 end

--- a/spec/symbols_spec.rb
+++ b/spec/symbols_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Sidekiq::Symbols do
+RSpec.describe Sidekiq::Symbols, sidekiq: :inline do
   class SampleJob
     include Sidekiq::Worker
     include Sidekiq::Symbols
@@ -20,9 +20,12 @@ describe Sidekiq::Symbols do
   end
 
   def expect_transformation(klass, *input, arg_signature)
-    expect(klass.new.perform(*input)).to eq(arg_signature)
     klass.perform_async(*input)
     expect($find_a_better_way_than_this).to eq(arg_signature)
+  end
+
+  before do
+    $find_a_better_way_than_this = nil
   end
 
   it "allows regular arguments" do
@@ -42,5 +45,75 @@ describe Sidekiq::Symbols do
     arg_signature = [[1], { x: { y: 2, z: { :"foo bar" => 0 } } }]
 
     expect_transformation(SampleJob, *input, arg_signature)
+  end
+
+  describe "subclassing" do
+    class SampleJobWithInheritedAfterInclude
+      include Sidekiq::Symbols
+
+      class <<self; attr_accessor :inherited_value; end
+
+      def self.inherited(subclass)
+        self.inherited_value = "original-inherited-value-after-include"
+      end
+    end
+
+    class SampleJobWithInheritedBeforeInclude
+      class <<self; attr_accessor :inherited_value; end
+
+      def self.inherited(subclass)
+        self.inherited_value = "original-inherited-value-before-include"
+      end
+
+      include Sidekiq::Symbols
+    end
+
+    class SubclassWithoutIncludeJob < SampleJob
+      def perform(*args, **kwargs)
+        $find_a_better_way_than_this = [args, kwargs]
+      end
+    end
+
+    class SubclassFoo < SampleJobWithInheritedAfterInclude; end
+    class SubclassBar < SampleJobWithInheritedBeforeInclude; end
+
+    it "works with subclasses that don't include the module directly" do
+      input = [1, "x" => { "y" => 2, z: { "foo bar" => 0 } }]
+      arg_signature = [[1], { x: { y: 2, z: { :"foo bar" => 0 } } }]
+
+      expect_transformation(SubclassWithoutIncludeJob, *input, arg_signature)
+    end
+
+    it "does not conflict with an existing self.inherited hook that appears after the include" do
+      expect(SampleJobWithInheritedAfterInclude.inherited_value).to eq("original-inherited-value-after-include")
+    end
+
+    it "does not conflict with an existing self.inherited hook that appears before the include" do
+      expect(SampleJobWithInheritedBeforeInclude.inherited_value).to eq("original-inherited-value-before-include")
+    end
+  end
+
+  # 2.1+ introduced required keyword arguments, so this must be done with
+  # eval to sidestep syntax errors at parse time.
+  if RUBY_VERSION >= "2.1.0"
+    # Note that this test is asserting that perform_async raises, but in
+    # reality it will actually raise at the Sidekiq server level when the worker
+    # tries to perform the job.
+    #
+    # perform_async itself won't raise because of missing required keyword args
+    # in actual code.
+    eval <<-DEFEAT_THE_PARSER
+      class SampleRequiredKeywordArgsJob
+        include Sidekiq::Worker
+        include Sidekiq::Symbols
+
+        def perform(x:)
+        end
+      end
+
+      it "raises on missing required keyword args" do
+        expect { SampleRequiredKeywordArgsJob.perform_async }.to raise_error(ArgumentError)
+      end
+    DEFEAT_THE_PARSER
   end
 end


### PR DESCRIPTION
This removes the requirement that every job class `include Sidekiq::Symbols`, even if a parent class already did it. Say you have this structure:

```ruby
class ApplicationJob
  include Sidekiq::Worker
  include Sidekiq::Symbols

  # ...
end

class FooJob < ApplicationJob
  def perform(x: 1)
    # ...
  end
end
```

Enqueueing a job for `FooJob` would _not_ allow symbol usage in the existing, previous implementation, because `ApplicationJob` is the class that `Sidekiq::Symbols` was prepended in front of.

```
ApplicationJob
      |
Sidekiq::Symbols
      |
    FooJob
```

So `FooJob` (and every other subclass of `ApplicationJob`) had to explicitly duplicate the `include Sidekiq::Symbols` line unless it called `super` or something similar.

This helps address #2.